### PR TITLE
fix link to GitHub Repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,8 +82,8 @@ find . -maxdepth 1 -type f -size -1M -exec wc -l {} + | sort -n -k1
 <h2>Links to the repos</h2>
 
 <ul>
-    <li><a href=https://github.com/TNG/please-cli">Please CLI Github Repo</a></li>
-    <li><a href="https://github.com/TNG/homebrew-please">Homebrew Tap Github Repo</a></li>
+    <li><a href="https://github.com/TNG/please-cli">Please CLI GitHub Repo</a></li>
+    <li><a href="https://github.com/TNG/homebrew-please">Homebrew Tap GitHub Repo</a></li>
 </ul>
 
 <h2>License</h2>


### PR DESCRIPTION
(and rename Github to GitHub)