### PR TITLE
Test if `xclip` is installed

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -325,7 +325,12 @@ copy_to_clipboard() {
       if [ "$XDG_SESSION_TYPE" == "wayland" ]; then
         echo -n "${command}" | wl-copy --primary
       else
-        echo -n "${command}" | xclip -selection clipboard
+        if command -v xclip &> /dev/null; then
+          echo -n "${command}" | xclip -selection clipboard
+        else
+          echo "xclip not installed. Exiting."
+          exit 1
+        fi
       fi
       ;;
     *)


### PR DESCRIPTION
Before executing `xclip`, test if it is installed. If not, abort.