### PR TITLE
Feature: Add word protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,23 @@ To store your API key using macOS keychain, run
 security add-generic-password -a "${USER}" -s OPENAI_API_KEY -w "${apiKey}"
 ```
 
+
+## Sensitive Word Protection
+
+In case would like to exclude parts of your request from being sent to OpenAI, you may protect them by surrounding them 
+in double curly braces `{{...}}`. In the payload sent to OpenAI, those words will then be replaced by placeholders.
+
+Example:
+The request
+```bash
+please list me all files that contain the word {{my name}}
+```
+will result in a payload `list me all files that contain the word %%%PLACEHOLDER-0%%%` that is sent to OpenAI. The placeholder
+is then re-substituted locally on your machine.
+
+_Careful:_ In order to protect words, you must exactly follow the style as proposed above (for example, no whitespaces between the curly braces).
+You may experiment with the `--debug` option in order to verify the desired behavior before you input actual sensitive data!
+
 ## Troubleshooting
 
 If you receive the following error message:

--- a/please.sh
+++ b/please.sh
@@ -340,20 +340,21 @@ act_on_action() {
 }
 
 execute_command() {
-    eval "${command}"
+    eval "$(resubstitute_escaped_words "${command}")"
 }
 
 copy_to_clipboard() {
+  resubstitutedCommand="$(resubstitute_escaped_words "${command}")"
   case "$(uname)" in
     Darwin*) # macOS
-      echo -n "${command}" | pbcopy
+      echo -n "${resubstitutedCommand}" | pbcopy
       ;;
     Linux*)
       if [ "$XDG_SESSION_TYPE" == "wayland" ]; then
-        echo -n "${command}" | wl-copy --primary
+        echo -n "${resubstitutedCommand}" | wl-copy --primary
       else
         if command -v xclip &> /dev/null; then
-          echo -n "${command}" | xclip -selection clipboard
+          echo -n "${resubstitutedCommand}" | xclip -selection clipboard
         else
           echo "xclip not installed. Exiting."
           exit 1


### PR DESCRIPTION
Add the possibility to protect words by putting them into {{ }} braces; ensures all payload sent to OpenAI are escaped this way; re-substitution only at the very end (in particular, to avoid protected words being finally sent from resubstituted answers in explain or "ask question" parts)

Downside: could lead to issues with certain payloads containing double braces by design - which then neeeded at least a whitespace; maybe some json payloads