### PR TITLE
Add encoding header to request

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -220,6 +220,7 @@ perform_openai_request() {
   IFS=$'\n' read -r -d '' -a result < <(curl "${openai_invocation_url}/chat/completions" \
        -s -w "\n%{http_code}" \
        -H "Content-Type: application/json" \
+       -H "Accept-Encoding: identity" \
        -H "Authorization: Bearer ${OPENAI_API_KEY}" \
        -d "${payload}" \
        --silent)


### PR DESCRIPTION
Add "identity" encoding header to request.

This allows to use alternative OpenAI proxies that might stream results.