### PR TITLE
feat: support case-insensitive input handling in menu selection

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -282,23 +282,23 @@ choose_action() {
           esac
         fi
         ;;
-      i)
+      "i"|"I")
         selected_option_index=0
         display_menu
         break
         ;;
 
-      c)
+      "c"|"C")
         selected_option_index=1
         display_menu
         break
         ;;
-      q)
+      "q"|"Q")
         selected_option_index=2
         display_menu
         break
         ;;
-      a)
+      "a"|"A")
         selected_option_index=3
         display_menu
         break


### PR DESCRIPTION
Modified the input handling mechanism to accept both uppercase and lowercase letters for menu navigation commands.

This change ensures the script can handle inputs more flexibly, accommodating both 'i' and 'I', 'c' and 'C', 'q' and 'Q', 'a' and 'A'.

This enhancement was prompted by user feedback that the interface displays uppercase letters for action prompts, leading to a natural expectation that uppercase inputs would be accepted (Issue #39).

This update aligns the script's functionality with user expectations, enhancing usability and accessibility during interactive sessions. Tested on MacOS 14.5 with bash v5.2 shell.

Resolves #39