### PR TITLE
feat: only output error message if LLM returns no actionable command

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -469,15 +469,15 @@ function main() {
   check_key
 
   get_command
+
+  if test "${command}" = "${fail_msg}"; then
+    exit 1
+  fi
   if [ "${explain}" -eq 1 ]; then
     explain_command
   fi
 
   print_option
-
-  if test "${command}" = "${fail_msg}"; then
-    exit 1
-  fi
 
   init_questions
   choose_action


### PR DESCRIPTION
The script now checks immediately if the returned command matches the designated failure message before proceeding with further actions like explanation or option printing.

This modification ensures that if the input prompt is unclear, the script directly outputs a clear error message and exits without executing additional unnecessary steps, aligning better with user expectations and reducing confusion.

This change improves user experience by providing immediate feedback on input validity and makes the script's flow more logical and efficient.

Resolves #52

Signed-off-by: Cornelius Roemer <cornelius.roemer@gmail.com>
