### PR TITLE
Documentation update

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 Please CLI
 
-Copyright 2023 TNG Technology Consulting GmbH
+Copyright 2025 TNG Technology Consulting GmbH
 
 This product includes software developed at
 TNG Technology Consulting GmbH (https://www.tngtech.com/).

--- a/README.md
+++ b/README.md
@@ -165,11 +165,16 @@ If you receive the following error message:
 
 ```bash
 Error: Received HTTP status 404
-The model: gpt-4 does not exist
 ```
 
-The API key you are using is not authorized to use GPT-4. You may also want to use the `--legacy` flag to use GPT-3.5 instead.
-You can also apply for GPT4 API access here: https://openai.com/waitlist/gpt-4-api
+There probably is an issue with your base URL. Please check the OpenAI API base URL in your environment variables.
+
+
+```bash
+Error: Received HTTP status 401
+```
+
+There probably is an issue with your OpenAI API key. Please check the OpenAI API key in your environment variables.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -175,4 +175,4 @@ You can also apply for GPT4 API access here: https://openai.com/waitlist/gpt-4-a
 
 Please CLI is published under the Apache License 2.0, see http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-Copyright 2023 TNG Technology Consulting GmbH
+Copyright 2025 TNG Technology Consulting GmbH


### PR DESCRIPTION
This PR updated the copyright notice to 2025 and removes outdated information about GPT4 not being available.

Additionally, it adds basic troubleshooting advise for common error codes.