### PR TITLE
Replace dpkg-sig package with debsigs

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup dpkg-dev
-        run: sudo apt-get install -y dpkg-dev gnupg2 dpkg-sig apt-utils
+        run: sudo apt-get install -y dpkg-dev gnupg2 devscripts debsigs apt-utils
 
       - name: Setup GPG
         env:
@@ -105,7 +105,7 @@ jobs:
           Description: An AI helper script to create CLI commands" > DEBIAN/control
           cd ..
           dpkg-deb --build please
-          dpkg-sig --sign builder please.deb
+          debsigs --sign=origin please.deb
 
       - name: Checkout apt repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Debian has removed the dpkg-sig package from its packages (see https://tracker.debian.org/pkg/dpkg-sig). The recommended replacement is to use debsigs from the devscripts package.

I created a minimal example of the release script (with some dummy variables) to verify that the debsig command runs through correctly:

Workflow Code:
https://github.com/JonathanRohland-TNG/please-cli/blob/fix/debug-package-signing-issue/.github/workflows/create-release.yml

Successful workflow execution:
https://github.com/JonathanRohland-TNG/please-cli/actions/runs/13229774184/job/36925267783