### PR TITLE
Update workflow actions to latest version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.APT_REPO_ACCESS_TOKEN }}
 

--- a/.github/workflows/create-pages.yml
+++ b/.github/workflows/create-pages.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -33,13 +33,13 @@ jobs:
           cp -r resources html/
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './html'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout apt repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: TNG/homebrew-please
           ref: main
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup dpkg-dev
         run: sudo apt-get install -y dpkg-dev gnupg2 devscripts debsigs apt-utils
@@ -108,7 +108,7 @@ jobs:
           debsigs --sign=origin please.deb
 
       - name: Checkout apt repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: TNG/apt-please
           ref: main
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup ssh for aur
         run: |
@@ -167,7 +167,7 @@ jobs:
           git push
 
       - name: Upload built package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: please-cli arch package ${{ github.ref }}
           path: please-cli/please-cli-*.pkg.tar


### PR DESCRIPTION
The workflow-actions `actions/upload-pages-artifact@v1` and `actions/upload-artifact@v3` are deprecated and don't work anymore (seehttps://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

This causes our workflows to fail: https://github.com/TNG/please-cli/actions/runs/13237321903/job/36944827800)