### PR TITLE
Update README.md with instructions for AUR helper installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ sudo apt-get install -f
 ### arch
 The latest release is in the AUR under the name [please-cli](https://aur.archlinux.org/packages/please-cli). It can be installed [manually](https://wiki.archlinux.org/title/Arch_User_Repository) or with [a helper](https://wiki.archlinux.org/title/AUR_helpers).
 
+#### Using an AUR helper (recommended)
+
+With [yay](https://github.com/Jguer/yay):
+```bash
+yay -S please-cli
+```
+
+With [paru](https://github.com/Morganamilo/paru):
+```bash
+paru -S please-cli
+```
+
+#### Manual installation
 Alternatively, you can build the package from source via
 ```bash
 wget https://raw.githubusercontent.com/TNG/please-cli/main/PKGBUILD

--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ With [paru](https://github.com/Morganamilo/paru):
 paru -S please-cli
 ```
 
+#### Using aurutils
+
+If you're using [aurutils](https://github.com/aurutils/aurutils) to manage AUR packages:
+
+```bash
+# First, ensure you have an aurutils repository set up
+# If not, follow the aurutils setup instructions first
+
+# Sync the AUR database and download the package
+aur sync please-cli
+
+# Install the package from your local repository
+sudo pacman -S please-cli
+```
+
 #### Manual installation
 Alternatively, you can build the package from source via
 ```bash


### PR DESCRIPTION
Add sections on using `yay` and `paru` for installing `please-cli` via AUR, along with manual installation instructions. This commit addresses https://github.com/TNG/please-cli/issues/35

(Note that I generated the instructions via GitHub Copilot, since I don't have access to an Arch-machine – requesting review by @NicholasTNG)