### PR TITLE
Support reasoning models

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -187,6 +187,11 @@ get_key_from_keychain() {
   PLEASE_OPENAI_API_KEY="${key}"
 }
 
+strip_reasoning() {
+  # Strip think blocks (both inline and multiline)
+  echo "$1" | sed 's/<think>.*<\/think>//g' | sed '/<think>/,/<\/think>/d'
+}
+
 get_command() {
   role="You translate the given input into a Linux command. You may not use natural language, but only a Linux shell command as an answer.
   Do not use markdown. Do not quote the whole output. If you do not know the answer, answer with \\\"${fail_msg}\\\"."
@@ -199,6 +204,7 @@ get_command() {
   debug "Sending request to OpenAI API: ${payload}"
 
   perform_openai_request
+  message=$(strip_reasoning "$message")
   command="${message}"
 }
 

--- a/test/strip_reasoning.bats
+++ b/test/strip_reasoning.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+load $BATS_TEST_DIRNAME/../please.sh
+
+@test "strip inline reasoning block" {
+  input="<think>thinking here</think>echo 'hello world'"
+  result=$(strip_reasoning "$input")
+  [ "$result" == "echo 'hello world'" ]
+}
+
+@test "strip multiline reasoning block" {
+  input="<think>
+thinking here
+more thinking
+</think>
+ls -la"
+  result=$(strip_reasoning "$input")
+  [ "$result" == "ls -la" ]
+}


### PR DESCRIPTION
Reasoning models prepend `<think>...</think>` to the actual answer in the response message. That part should obviously not be included in the command string suggested by please-cli.