### PR TITLE
fix: resolve VERSION_NUMBER placeholder shown in --version output

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -36,6 +36,12 @@ prepare() {
 
   # Patching the install command in an error message.
   sed -i -e 's/sudo apt install libsecret-tools/sudo pacman -S libsecret/' 'please.sh'
+
+  # Replace VERSION_NUMBER placeholder with the actual version derived from git tags.
+  _pkgver=$(git tag --sort=v:refname | tail -n1)
+  if [ -n "$_pkgver" ]; then
+    sed -i -e "s/VERSION_NUMBER/${_pkgver#v}/" 'please.sh'
+  fi
 }
 
 package() {

--- a/please.sh
+++ b/please.sh
@@ -114,8 +114,27 @@ function store_api_key() {
     done
 }
 
+_version="VERSION_NUMBER"
+
+_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 display_version() {
-  echo "Please vVERSION_NUMBER"
+  # The placeholder VERSION_NUMBER is replaced with the actual version by the
+  # bump-version CI workflow via sed. If it is still the literal string, the
+  # script is running from source or an unpatched install — fall back to git tags.
+  if [ "$_version" = "VERSION_NUMBER" ]; then
+    if [ -d "${_script_dir}/.git" ]; then
+      local _tag
+      _tag=$(cd "$_script_dir" && git tag --sort=v:refname 2>/dev/null | tail -n1)
+      if [ -n "$_tag" ]; then
+        echo "Please v${_tag#v}"
+        return
+      fi
+    fi
+    echo "Please vVERSION_NUMBER"
+  else
+    echo "Please v$_version"
+  fi
 }
 
 display_help() {

--- a/test/main.bats
+++ b/test/main.bats
@@ -10,4 +10,15 @@ PLEASE_EXE=$BATS_TEST_DIRNAME/../please.sh
 @test "smoke test please --version" {
   result=$($PLEASE_EXE '--version')
   [ "${result:0:8}" == "Please v" ]
+  [[ "${result}" != *"VERSION_NUMBER"* ]]
+}
+
+@test "version fallback derives version from git tags" {
+  _latest_tag=$(cd "$BATS_TEST_DIRNAME/.." && git tag --sort=v:refname | tail -n1)
+  if [ -z "$_latest_tag" ]; then
+    skip "No git tags available"
+  fi
+  _latest_tag="${_latest_tag#v}"
+  result=$($PLEASE_EXE '--version')
+  [ "$result" == "Please v${_latest_tag}" ]
 }


### PR DESCRIPTION
When please-cli is installed from AUR or run from source, the VERSION_NUMBER placeholder was never replaced, causing 'please -v' to print 'Please vVERSION_NUMBER' instead of the actual version.

- Add git-tag fallback in display_version() when placeholder is still present (covers running from source / git clone)
- Add sed replacement in PKGBUILD prepare() (covers AUR installs)
- Add test asserting --version output contains a real version